### PR TITLE
Spec compatibility fixes for building on more distributions

### DIFF
--- a/openssh-ldap-authkeys.spec
+++ b/openssh-ldap-authkeys.spec
@@ -50,7 +50,7 @@ Requires(pre):	%{_sbindir}/useradd
 %endif
 
 # This is only for cases that we don't have a dependency generator active...
-%if (0%{?rhel} && 0%{?rhel} < 8) || 0%{?suse_version} || 0%{?debian} || 0%{?ubuntu}
+%if %{undefined python_enable_dependency_generator} && %{undefined python_disable_dependency_generator}
 Requires:	python%{python3_pkgversion}-ldap
 
 # Names are fun...

--- a/openssh-ldap-authkeys.spec
+++ b/openssh-ldap-authkeys.spec
@@ -93,6 +93,12 @@ to who used them.
 %{_sysusersdir}/openssh-ldap-authkeys.sysusers.conf
 %{_tmpfilesdir}/openssh-ldap-authkeys.tmpfiles.conf
 
+%if 0%{?el7}
+%post
+%sysusers_create %{name}.sysusers.conf
+%tmpfiles_create %{name}.tmpfiles.conf
+%endif
+
 %if "%{_vendor}" == "debbuild"
 %post
 %sysusers_create %{name}.sysusers.conf

--- a/openssh-ldap-authkeys.spec
+++ b/openssh-ldap-authkeys.spec
@@ -3,7 +3,7 @@
 
 Name:		openssh-ldap-authkeys
 Version:	0.2.0
-Release:	1%{?dist}
+Release:	0%{?dist}
 Summary:	Python script to generate SSH authorized_keys files using an LDAP directory
 
 %if "%{_vendor}" == "debbuild"
@@ -111,5 +111,8 @@ to who used them.
 
 
 %changelog
+* Fri Nov 11 2022 Dan Fuhry <dan@fuhry.com> - 0.2.0
+- New release
+
 * Fri Feb 22 2019 Neal Gompa <ngompa13@gmail.com> - 0.1.0
 - Initial release

--- a/openssh-ldap-authkeys.spec
+++ b/openssh-ldap-authkeys.spec
@@ -1,7 +1,7 @@
 # Enable Python dependency generation for Fedora and EL8+
 %{?python_enable_dependency_generator}
 
-%if %{_vendor} == "debbuild"
+%if "%{_vendor}" == "debbuild"
 	%global _buildshell /bin/bash
 	%global devsuffix dev
 %else
@@ -13,7 +13,7 @@ Version:	0.2.0
 Release:	1%{?dist}
 Summary:	Python script to generate SSH authorized_keys files using an LDAP directory
 
-%if %{_vendor} == "debbuild"
+%if "%{_vendor}" == "debbuild"
 Packager:	Dan Fuhry <dan@fuhry.com>
 Group:		admin
 %endif
@@ -34,7 +34,7 @@ BuildRequires:	systemd
 BuildRequires:	python%{python3_pkgversion}-%{devsuffix}
 BuildRequires:	python%{python3_pkgversion}-setuptools
 
-%if %{_vendor} == "debbuild"
+%if "%{_vendor}" == "debbuild"
 BuildRequires:	python3-deb-macros
 BuildRequires:	systemd-deb-macros
 # Compatibility with dsc packaging?
@@ -54,13 +54,13 @@ Requires(pre):	%{_sbindir}/useradd
 Requires:	python%{python3_pkgversion}-ldap
 
 # Names are fun...
-%if %{_vendor} == "redhat"
+%if "%{_vendor}" == "redhat"
 Requires:	python%{python3_pkgversion}-dns
 %else
 Requires:	python%{python3_pkgversion}-dnspython
 %endif
 
-%if %{_vendor} == "suse"
+%if "%{_vendor}" == "suse"
 Requires:	python%{python3_pkgversion}-PyYAML
 %else
 Requires:	python%{python3_pkgversion}-yaml
@@ -95,7 +95,7 @@ to who used them.
 
 
 %files
-%if %{_vendor} == "debbuild"
+%if "%{_vendor}" == "debbuild"
 %license debian/copyright
 %endif
 %license COPYING
@@ -117,7 +117,7 @@ getent passwd olak >/dev/null || \
 exit 0
 
 
-%if %{_vendor} == "debbuild"
+%if "%{_vendor}" == "debbuild"
 %post
 %{sysusers_create %{name}.sysusers.conf}
 %{tmpfiles_create %{name}.tmpfiles.conf}


### PR DESCRIPTION
This PR contains a couple of fixes for improving compatibility with distributions, including fixes for RPM 4.16+ compatibility (Fedora 33+).