### PR TITLE
Restructure RPM packaging spec and rework SELinux module packaging

### DIFF
--- a/selinux/Makefile
+++ b/selinux/Makefile
@@ -1,0 +1,17 @@
+TARGETS?= olak
+SHARE?=/usr/share
+MODULES?=${TARGETS:=.pp.bz2}
+
+all: ${TARGETS:=.pp.bz2}
+
+%.pp.bz2: %.pp
+	@echo Compressing $^ -\ $@
+	bzip2 -9 $^
+
+%.pp: %.te
+	make -f ${SHARE}/selinux/devel/Makefile $@
+
+clean:
+	rm -f *~ *.tc *.pp *.pp.bz2
+	rm -rf tmp
+


### PR DESCRIPTION
The SELinux policy module packaging is now reworked to more closely match the packaging guidelines for packaging independent SELinux policy modules.

In order to make things more readable, the preamble, scriptlets, and file lists are now grouped together per binary package.